### PR TITLE
fix: next version of ppxlib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,17 @@
       let
         pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [
           (self: super: {
-            ocamlPackages = super.ocaml-ng.ocamlPackages_5_1;
+            ocamlPackages = super.ocaml-ng.ocamlPackages_5_1.overrideScope' (oself: osuper: {
+              ppxlib = osuper.ppxlib.overrideAttrs (_: {
+                src = super.fetchFromGitHub {
+                  owner = "ocaml-ppx";
+                  repo = "ppxlib";
+                  rev = "4026b795d9b9bd44beaf11b790a7f9a26fc0aa63";
+                  hash = "sha256-dRWHkE9aZS7gQp5CAT8qCX/uKYEbiIy7our5XXgMHGI=";
+                };
+
+              });
+            });
           })
           melange-src.overlays.default
         ];

--- a/src/Webapi/Dom/Webapi__Dom__Document.re
+++ b/src/Webapi/Dom/Webapi__Dom__Document.re
@@ -162,7 +162,9 @@ include Webapi__Dom__EventTarget.Impl({
 include Webapi__Dom__NonElementParentNode.Impl({
   type nonrec t = t;
 });
-include Webapi__Dom__DocumentOrShadowRoot.Impl();
+include Webapi__Dom__DocumentOrShadowRoot.Impl({
+  ();
+});
 include Webapi__Dom__ParentNode.Impl({
   type nonrec t = t;
 });

--- a/src/Webapi/Dom/Webapi__Dom__DocumentOrShadowRoot.re
+++ b/src/Webapi/Dom/Webapi__Dom__DocumentOrShadowRoot.re
@@ -1,4 +1,2 @@
 /* Mixin */
-module Impl = (T: {}) => {
-  /* TODO: Implemented in Shadow DOM spec */
-};
+module Impl = (T: {}) => {/* TODO: Implemented in Shadow DOM spec */};

--- a/src/Webapi/Dom/Webapi__Dom__ShadowRoot.re
+++ b/src/Webapi/Dom/Webapi__Dom__ShadowRoot.re
@@ -9,7 +9,7 @@ include Webapi__Dom__EventTarget.Impl({
 include Webapi__Dom__NonElementParentNode.Impl({
   type nonrec t = t;
 });
-include Webapi__Dom__DocumentOrShadowRoot.Impl();
+include Webapi__Dom__DocumentOrShadowRoot.Impl({ (); });
 include Webapi__Dom__ParentNode.Impl({
   type nonrec t = t;
 });


### PR DESCRIPTION
- The next version of ppxlib enforces generative functor application, and produces errors in the cases changed in this PR
- unfortunately Reason formats `Foo({})` to `Foo()`, i.e. there seems to be no distinction between OCaml's `Foo(struct end)` and `Foo()`
  - this will probably have to be fixed upstream
- for now we use `{ (); }` to force a single structure item