### PR TITLE
feat: bind to new FormData(HtmlFormElement)

### DIFF
--- a/src/Webapi.re
+++ b/src/Webapi.re
@@ -13,7 +13,13 @@ module File = Webapi__File;
     [Webapi.Dom.HtmlFormElement.data].
 
     @since 0.18.0 */
-module FormData = Fetch.FormData;
+module FormData = {
+  include Fetch.FormData;
+
+  [@mel.new]
+  external makeWithHtmlFormElement: (Dom.HtmlFormElement.t) => t =
+    "FormData";
+};
 
 /** Re-export from [bs-fetch] for convenience. See also
     {!module:FormData}.


### PR DESCRIPTION
Adds a binding to `new FormData(HtmlFormElement)`.

Thought to add it to `melange-fetch` first but it doesn't depend on `melange.dom` so maybe `melange-webapi` is a better choice then. But let me know if this change should be made against `melange-fetch`.
