### PR TITLE
re_export melange.dom

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
  (name webapi)
  (public_name melange-webapi)
  (wrapped false)
- (libraries melange-fetch melange.dom)
+ (libraries melange-fetch (re_export melange.dom))
  (modes melange)
  (preprocess
   (pps melange.ppx)))


### PR DESCRIPTION
Hello,

I had an issue building a project with dune `(implicit_transitive_deps false)` option.
This re-export melange.dom so the subtyping works